### PR TITLE
Fix setup path for order service

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This repository contains a basic e-commerce system built using microservices arc
      ```
    - **Order Service:**
      ```bash
-     cd order-service
+     cd publish-order-service
      go run main.go
      ```
 


### PR DESCRIPTION
## Summary
- correct order service path in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683f5f6f54208320823d09eb0faa2a32