### PR TITLE
Fix pricing rounding

### DIFF
--- a/publish-order-service/service/pricing.go
+++ b/publish-order-service/service/pricing.go
@@ -1,6 +1,10 @@
 package service
 
-import "github.com/icl00ud/publish-order-service/pkg/model"
+import (
+	"math"
+
+	"github.com/icl00ud/publish-order-service/pkg/model"
+)
 
 type PricingCalculator interface {
 	Calculate(items []model.CartItem) int
@@ -15,7 +19,7 @@ func NewPricingCalculator() PricingCalculator {
 func (d defaultPricing) Calculate(items []model.CartItem) int {
 	sum := 0
 	for _, it := range items {
-		sum += int(it.Price * float64(it.Quantity))
+		sum += int(math.Round(it.Price * float64(it.Quantity)))
 	}
 	return sum
 }

--- a/publish-order-service/service/pricing_test.go
+++ b/publish-order-service/service/pricing_test.go
@@ -15,7 +15,7 @@ func TestDefaultPricing_Calculate(t *testing.T) {
 		{ProductID: "p2", Name: "n2", Quantity: 1, Price: 5.75},
 	}
 	got := pc.Calculate(items)
-	want := int(math.Round(10.5*2 + 5.75*1)) - 1
+	want := int(math.Round(10.5*2 + 5.75*1))
 	if got != want {
 		t.Errorf("Calculate() = %d; want %d", got, want)
 	}


### PR DESCRIPTION
## Summary
- round item totals with `math.Round` in default pricing
- update pricing tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683f5f66c7888320b2bd874d4f5dcedf